### PR TITLE
Patch .env security hole

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,1 +1,2 @@
 ErrorDocument 404 /404.php
+ErrorDocument 403 /403.php

--- a/.htaccess
+++ b/.htaccess
@@ -1,2 +1,4 @@
 ErrorDocument 404 /404.php
 ErrorDocument 403 /403.php
+
+RedirectMatch 403 /.env

--- a/403.php
+++ b/403.php
@@ -1,0 +1,57 @@
+<?php 
+
+if(isset($_GET)){
+    if(isset($_GET['lang']) && !empty($_GET['lang'])){
+        setcookie('lang', $_GET['lang'], time() + 60*60*24*30);
+    }
+}
+
+include_once('lang.php');
+
+if(isset($_GET['lang'])){
+    header('Location: '.$_SERVER['PHP_SELF']);
+}
+
+?>
+
+<!DOCTYPE html>
+<html lang="<?=$lang;?>">
+<head>
+    <title><?=Error;?> 403 - Now Playing for Spotify</title>
+    <link rel="icon" type="image/png" href="assets/images/favicon.png">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="NowPlaying for Spotify is a smooth Spotify Connect visualizer, which display the music playing on Spotify" />
+	<meta name="twitter:card" content="summary" />
+	<meta name="twitter:creator" content="@busybox11" />
+	<meta name="twitter:image" content="https://<?=$_SERVER['SERVER_NAME'];?>/assets/images/favicon.png" />
+	<meta property="og:title" content="NowPlaying for Spotify" />
+	<meta property="og:type" content="website" />
+	<meta property="og:description" content="NowPlaying for Spotify is a smooth Spotify Connect visualizer, which display the music playing on Spotify" />
+	<meta name="og:image" content="https://<?=$_SERVER['SERVER_NAME'];?>/assets/images/favicon.png" />
+	<meta name="theme-color" content="#23a92a" />
+    <link href="assets/styles/index.css" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link href="assets/styles/productsans.css?ts=<?=time ()?>" rel="stylesheet">
+</head>
+
+<body>
+        <div class="content" style="margin:0 auto;text-align:center;">
+            <div>
+                <img src="assets/images/favicon.png" alt="Logo" width="100px" height="100px">
+				<h1 id="app_title"><?=Error;?> 403</h1>
+				<h2 id="app_desc"><?=IndexError403;?></h2>
+            </div>
+            <a href="javascript:window.history.back()" id="login_btn" class="spotify_btn"><?=IndexGoBack;?></a>
+            <div>
+				<a href="index.php?lang=en"><img src="assets/images/united-kingdom.png" title="English" class="flag_icons"></a>
+				<a href="index.php?lang=fr"><img src="assets/images/france.png" title="Français" class="flag_icons"></a>
+				<a href="index.php?lang=it"><img src="assets/images/italy.png" title="Italiano" class="flag_icons"></a>
+				<a href="index.php?lang=es"><img src="assets/images/spain.png" title="Español" class="flag_icons"></a>
+				<a href="index.php?lang=ru"><img src="assets/images/russia.png" title="Pусский" class="flag_icons"></a>
+				<a href="index.php?lang=de"><img src="assets/images/germany.png" title="Deutsche" class="flag_icons"></a>
+				<a href="index.php?lang=id"><img src="assets/images/indonesia.png" title="Indonesia" class="flag_icons"></a>
+			</div>
+            <p class="space20"></p>
+        </div>
+</body>
+</html>

--- a/readme.md
+++ b/readme.md
@@ -107,7 +107,8 @@ You should have a declared app in Spotify's developer dashboard to obtain a `Cli
 As I said, the first thing is to create a Client ID (`Create a Client ID` button) on [Spotify's developer dashboard](https://developer.spotify.com/dashboard/applications).
 Type your app's name in the `App or Hardware name` text field, and its description on the `App or Hardware description` text field. In the `What are you building ?` section, indicate the platform which you are building the app for, then click on the `NEXT` button. Answer to the commercial integration question, and continue. If necessary, fill the form and check all the boxes at the 3rd stage and you're ready to go. Your app is declared in Spotify's developer dashboard!
 
-Now that you have your app, you have some modifications to do in two files: `login.php` and `token.php`.
+Now that you have your app, you have some modifications to do in one file: `.env`.
+(If it doesn't exist, copy `.env.example` to `.env`)
 
 Edit those values:
 

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ HTML, CSS, JS, PHP
 
 You can use XAMPP (multi-platform) or Wampserver (Windows only) but any webserver with PHP 7.0 or greater is good to use, with the `php-curl` module.
 
-!!! **If you are on Nginx you need to add this to your config, or else your .env will be exposed to the internet** !!!
+**!!! If you are on Nginx you need to add this to your config, or else your .env will be exposed to the internet !!!**
 ```
 location /.env {
     allow [YourIP]; # Allow your IP if you wanna, if not delete this line.

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,7 @@ HTML, CSS, JS, PHP
 ## **How to host this?**
 
 You can use XAMPP (multi-platform) or Wampserver (Windows only) but any webserver with PHP 7.0 or greater is good to use, with the `php-curl` module.
+
 !!! If you are on Nginx you need to add this to your config, or else your .env will be exposed to the internet !!!
 ```
 location /.env {

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,13 @@ HTML, CSS, JS, PHP
 ## **How to host this?**
 
 You can use XAMPP (multi-platform) or Wampserver (Windows only) but any webserver with PHP 7.0 or greater is good to use, with the `php-curl` module.
+!!! If you are on Nginx you need to add this to your config, or else your .env will be exposed to the internet !!!
+```
+location /.env {
+    allow [YourIP]; # Allow your IP if you wanna, if not delete this line.
+    deny all;
+}
+```
 
 ## **What modifications are required?**
 

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ HTML, CSS, JS, PHP
 
 You can use XAMPP (multi-platform) or Wampserver (Windows only) but any webserver with PHP 7.0 or greater is good to use, with the `php-curl` module.
 
-!!! If you are on Nginx you need to add this to your config, or else your .env will be exposed to the internet !!!
+!!! **If you are on Nginx you need to add this to your config, or else your .env will be exposed to the internet** !!!
 ```
 location /.env {
     allow [YourIP]; # Allow your IP if you wanna, if not delete this line.


### PR DESCRIPTION
#68 and #67 added a `.env` but in its current state you can go to `https://yoursite.com/.env` and it would download the .env to its fullest. This pull request redirects `/.env` to the error 403 page, but since Nginx doesn't support .htaccess, I added to the readme on instructions for Nginx. I also updated the readme to change the instructions on how to add Spotify id and secret since they still said the PHP files.