### PR TITLE
Add wakelock on fullscreen to prevent screen from sleeping

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -45,6 +45,28 @@ function setCookie(cname, cvalue, exdays) {
     document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
 }
 
+/* WakeLock */
+let wakelock = null;
+
+/* Prevent screen from sleeping */
+function getWakelock() {
+    if ('wakeLock' in navigator) {
+        navigator.wakeLock.request('screen').then(function (wakeLock) {
+            wakelock = wakeLock;
+        }).catch(function (err) {
+            console.log(`Failed to request wake lock: ${err}`);
+        });
+    }
+}
+
+/* Release the wake lock */
+function releaseWakelock() {
+    if (wakelock !== null) {
+        wakelock.release();
+        wakelock = null;
+    }
+}
+
 /* Fullscreen */
 let elem = document.documentElement;
 
@@ -59,6 +81,7 @@ function openFullscreen() {
     } else if (elem.msRequestFullscreen) { /* IE/Edge */
         elem.msRequestFullscreen();
     }
+    getWakelock();
 }
 
 /* Close fullscreen */
@@ -72,6 +95,7 @@ function closeFullscreen() {
     } else if (document.msExitFullscreen) { /* IE/Edge */
         document.msExitFullscreen();
     }
+    releaseWakelock();
 }
 
 function fullscreen() {


### PR DESCRIPTION
I want to start by saying thank you for creating such a fantastic "Now Playing" app! I've been using it to turn my spare tablet into a dedicated music monitor, and it works beautifully.

However, I encountered a small hurdle: after a while of inactivity, the tablet dims and eventually goes to sleep, requiring me to interact with it to wake it back up. While I can adjust the power settings to prevent this, I remembered a handy JavaScript browser API called Wake Lock that could potentially handle this for us.

In my specific use case, I'd love for the app to stay awake when in fullscreen mode. Therefore, I implemented this functionality in the attached pull request. Of course, I'm open to discussing different approaches!